### PR TITLE
Added semi-transparent background to navbar and captions

### DIFF
--- a/themes/ryan-clean-blog/static/css/clean-blog.min.css
+++ b/themes/ryan-clean-blog/static/css/clean-blog.min.css
@@ -67,7 +67,7 @@ hr.small {
 }
 @media only screen and (min-width: 768px) {
     .navbar-custom {
-        background: 0 0;
+        background: rgba(0, 0, 0, 0.20);
         border-bottom: 1px solid transparent
     }
     .navbar-custom .navbar-brand {
@@ -253,6 +253,7 @@ hr.small {
     font-weight: 700
 }
 .header-caption {
+    background: rgba(0, 0, 0, 0.25);
     text-align: right;
     color: #fff;
     font-size: 14px;


### PR DESCRIPTION
Added a `.20` transparent background color to the navbar and a `.25` one to the header caption.

It helps with reading it but not sure if I love the look 100% yet. I wonder if it makes the header image feel more boxed in...

I think a better solution might be to have it do it just behind the text if I can? Maybe at least for the caption since it's such a small part of that bottom row.

Anyhow, it resolves the problem stated in Issue #14.

Closes #14 